### PR TITLE
17.0.6 Add back changes we want in our recipe skip CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
+noarch_upload:
+  - all
+
 # Don't skip-existing, it doesn't play well with multi-output feedstocks
 build_parameters:
   - "--suppress-variables"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
-upload_without_merge: True
-upload_to_staging_channel_in_pr: True
-channels: [ llvmdev17 ]
+channels:
+  - https://staging.continuum.io/prefect/llvm-17.0.6-stage2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/llvm-17.0.6-stage2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,10 +1,7 @@
-noarch_upload:
-  - all
-
-# Don't skip-existing, it doesn't play well with multi-output feedstocks
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-channels:
-  - https://staging.continuum.io/prefect/fs/clangdev-feedstock/pr4/b5c20c8
+upload_without_merge: True
+upload_to_staging_channel_in_pr: True
+channels: [ llvmdev17 ]

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/clangdev-feedstock/pr4/b5c20c8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,7 @@
+# Don't skip-existing, it doesn't play well with multi-output feedstocks
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
 channels:
   - https://staging.continuum.io/prefect/fs/clangdev-feedstock/pr4/b5c20c8

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -56,20 +56,6 @@ else
     CMAKE_ARGS="$CMAKE_ARGS -DCOMPILER_RT_HAS_LIBSTDCXX=1"
 fi
 
-# make sure we use our pre-built libcxx, see
-# https://github.com/llvm/llvm-project/blame/llvmorg-14.0.0/compiler-rt/CMakeLists.txt#L178-L181
-export CMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -stdlib=libcxx"
-# the following option is confusingly named; it means not rebuild libcxx, see
-# https://github.com/llvm/llvm-project/blame/llvmorg-14.0.0/compiler-rt/CMakeLists.txt#L607-L608
-CMAKE_ARGS="$CMAKE_ARGS -DCOMPILER_RT_USE_LIBCXX=OFF"
-
-# point compiler-rt to correct C++ stdlib
-if [[ "$target_platform" == osx-* ]]; then
-    CMAKE_ARGS="$CMAKE_ARGS -DCOMPILER_RT_HAS_LIBCXX=1"
-else
-    CMAKE_ARGS="$CMAKE_ARGS -DCOMPILER_RT_HAS_LIBSTDCXX=1"
-fi
-
 cmake \
     -G "Ninja" \
     -DCMAKE_BUILD_TYPE="Release" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+cd ${SRC_DIR}
 
 if [[ "$target_platform" == osx-* ]]; then
     ls -al ${CONDA_BUILD_SYSROOT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,11 @@ set -ex
 
 if [[ "$target_platform" == osx-* ]]; then
     ls -al ${CONDA_BUILD_SYSROOT}
-    CMAKE_ARGS="$CMAKE_ARGS -DDARWIN_osx_ARCHS=x86_64;arm64 -DCOMPILER_RT_ENABLE_IOS=Off"
+    if [[ "$target_platform" == osx-arm64 ]]; then
+      CMAKE_ARGS="$CMAKE_ARGS -DDARWIN_osx_ARCHS=arm64 -DCOMPILER_RT_ENABLE_IOS=Off"
+    else
+      CMAKE_ARGS="$CMAKE_ARGS -DDARWIN_osx_ARCHS=x86_64 -DCOMPILER_RT_ENABLE_IOS=Off"
+    fi
     CMAKE_ARGS="$CMAKE_ARGS -DDARWIN_macosx_CACHED_SYSROOT=${CONDA_BUILD_SYSROOT} -DDARWIN_macosx_OVERRIDE_SDK_VERSION=${MACOSX_SDK_VERSION}"
     unset CFLAGS
     unset CXXFLAGS

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ex
-cd ${SRC_DIR}
 
 if [[ "$target_platform" == osx-* ]]; then
     ls -al ${CONDA_BUILD_SYSROOT}
@@ -97,6 +96,9 @@ rm -rf "${PREFIX}/lib/libc++.tbd"
 
 if [[ "$target_platform" == "$build_platform" ]]; then
   RESOURCE_DIR=$(${PREFIX}/bin/clang -print-resource-dir)
+  # /tmp, where the builds happen, is actually a symlink to /private/tmp.
+  # clang's output includes the preceding /private, whereas ${PREFIX} does not, leading to this check failing.
+  RESOURCE_DIR=${RESOURCE_DIR#/private}
   if [[ "${RESOURCE_DIR}" != "${INSTALL_PREFIX}" ]]; then
     echo "Wrong install prefix (${INSTALL_PREFIX}). Should match ${RESOURCE_DIR}"
     exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,7 @@ c_compiler:          # [osx]
 cxx_compiler:        # [osx]
   - clang_bootstrap  # [osx]
 
-# channel_sources:
-#   - conda-forge/label/llvm_rc,conda-forge
-# channel_targets:
-#   - conda-forge llvm_rc
+c_compiler_version:
+  - 17.0.6            # [osx]
+cxx_compiler_version:
+  - 17.0.6            # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,11 +1,9 @@
-MACOSX_SDK_VERSION:  # [osx]
-  - 11.0             # [osx]
 c_compiler:          # [osx]
   - clang_bootstrap  # [osx]
 cxx_compiler:        # [osx]
   - clang_bootstrap  # [osx]
 
-channel_sources:
-  - conda-forge/label/llvm_rc,conda-forge
-channel_targets:
-  - conda-forge llvm_rc
+# channel_sources:
+#   - conda-forge/label/llvm_rc,conda-forge
+# channel_targets:
+#   - conda-forge llvm_rc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 1
+  skip: True  # [linux and s390x]
 
 requirements:
   build:
@@ -26,8 +27,8 @@ requirements:
     - clangdev {{ version }}
     - llvmdev {{ version }}
     - libcxx   # [osx]
-    - zlib
-    - libxml2
+    - zlib {{ zlib }}
+    - libxml2 {{ libxml2 }}
 
 outputs:
   - name: compiler-rt_{{ target_platform }}
@@ -82,11 +83,13 @@ outputs:
         - if not exist %LIBRARY_LIB%\clang\{{ major_ver }}\lib\windows\clang_rt.builtins-x86_64.lib exit 1  # [win]
 
 about:
-  home: http://llvm.org/
+  home: https://llvm.org/
   license: Apache-2.0 WITH LLVM-exception
   license_file: compiler-rt/LICENSE.TXT
+  license_family: Apache
   summary: compiler-rt runtime libraries
   dev_url: https://github.com/llvm/llvm-project
+  doc_url: https://llvm.org/docs/
   description: |
     builtins - low-level target-specific hooks required by code generation and other
       runtime components

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   host:
     - clangdev {{ version }}
     - llvmdev {{ version }}
-    - libcxx   # [osx]
+    - libcxx  {{ version }}   # [osx]
     - zlib {{ zlib }}
     - libxml2 {{ libxml2 }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ requirements:
 outputs:
   - name: compiler-rt_{{ target_platform }}
     build:
-      noarch: generic
       ignore_run_exports_from:
         - {{ compiler('cxx') }}
       detect_binary_files_with_prefix: false  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - {{ compiler('cxx') }}
     - python *
     - ninja
+    - patch     # [not win]
+    - m2-patch  # [win]
     - llvmdev {{ version }}  # [build_platform != target_platform]
   host:
     - clangdev {{ version }}


### PR DESCRIPTION
- don't build universal binaries on osx platforms
- use our osx sdk versions as a first punt (might need to be upgraded to 11.0/11.1 on x86_64
- comment out channel_sources and channel_targets, they're c-f specific
- skip s390x
- explicitly pin zlib and libxml2 to cbc
- add back in our about: changes