### PR TITLE
Update to LLVM 21.1.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -4,8 +4,11 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Stage 0: Bootstrap build - needs clangdev 21 from stage0 channel
-staging_channel_upload_target: llvm-21.1.8-stage0-build-0
+# Stage 2: Build with clang 21 compiler
+staging_channel_upload_target: llvm-21.1.8-stage2-build-0
 
 channels:
+  # Stage 2 channel has clang_bootstrap 21
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+  # Stage 0 channel has supporting packages
   - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,11 @@
+aggregate_check: false
+
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"
+
+# Stage 0: Bootstrap build - needs clangdev 21 from stage0 channel
+staging_channel_upload_target: llvm-21.1.8-stage0-build-0
+
+channels:
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,14 +1,9 @@
-aggregate_check: false
-
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Stage 2: Build with clang 21 compiler
-staging_channel_upload_target: llvm-21.1.8-stage2-build-0
-
+# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
 channels:
-  # Stage 2 channel has clang_bootstrap 21
   - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-  # Stage 0 channel has supporting packages
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0
+
+aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,6 @@ c_compiler:          # [osx]
 cxx_compiler:        # [osx]
   - clang_bootstrap  # [osx]
 
-# Stage 2: Build with clang 21 compiler
 c_compiler_version:   # [osx]
   - 21.1.8            # [osx]
 cxx_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,10 +3,11 @@ c_compiler:          # [osx]
 cxx_compiler:        # [osx]
   - clang_bootstrap  # [osx]
 
+# Stage 2: Build with clang 21 compiler
 c_compiler_version:   # [osx]
-  - 20.1.8            # [osx]
+  - 21.1.8            # [osx]
 cxx_compiler_version:
-  - 20.1.8            # [osx]
+  - 21.1.8            # [osx]
 
 # Keep consistent with llvmdev and clangdev
 c_compiler:        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ outputs:
       ignore_run_exports_from:
         - {{ compiler('cxx') }}
       detect_binary_files_with_prefix: false  # [win]
+      missing_dso_whitelist:                  # [linux]
+        - "*/libstdc++.so.6"                  # [linux]
+        - "*/libgcc_s.so.1"                   # [linux]
     requirements:
       build:
         - {{ compiler('cxx') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.1.8" %}
+{% set version = "21.1.8" %}
 {% set major_ver = version.split('.')[0] %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
+  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
   patches:
     - patches/0001-no-code-sign.patch
     - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch


### PR DESCRIPTION
**Destination channel:** defaults

  ### Links

  - [PKG-10604](https://jira.anaconda.com/browse/PKG-10604)
  - [Upstream repository](https://github.com/llvm/llvm-project)
  - [Upstream changelog/diff](https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.8)
  - 
  ### Related PRs

  - AnacondaRecipes/llvmdev-feedstock#33
  - AnacondaRecipes/clangdev-feedstock#21
  - AnacondaRecipes/libcxx-feedstock#22
  - AnacondaRecipes/cctools-and-ld64-feedstock#18
  - AnacondaRecipes/clang-compiler-activation-feedstock#24
  - AnacondaRecipes/lld-feedstock#13
  - AnacondaRecipes/mlir-feedstock#10

  ### Explanation of changes:

  - Updated compiler-rt from 20.1.8 to 21.1.8
  - Updated source SHA256 for new release
  - Part of LLVM 21 toolchain update
  - Stage 2 build using clang_bootstrap 21.1.8 compiler
  - Packages built:
    - `compiler-rt_osx-arm64`
    - `compiler-rt_osx-64`
    - `compiler-rt_linux-64`
    - `compiler-rt_linux-aarch64`

[PKG-10604]: https://anaconda.atlassian.net/browse/PKG-10604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ