### PR TITLE
Update compiler-rt to 22.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
+# All LLVM 22 packages on anaconda.org (bypass PBP staging, SIR-2834)
 channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+  - https://conda.anaconda.org/xkong-staging
 
 aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,10 +3,11 @@ c_compiler:          # [osx]
 cxx_compiler:        # [osx]
   - clang_bootstrap  # [osx]
 
+# Stage 2: Self-hosted build with clang 22
 c_compiler_version:   # [osx]
-  - 21.1.8            # [osx]
+  - 22.1.2            # [osx]
 cxx_compiler_version:
-  - 21.1.8            # [osx]
+  - 22.1.2            # [osx]
 
 # Keep consistent with llvmdev and clangdev
 c_compiler:        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 {% set major_ver = version.split('.')[0] %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
+  sha256: a252efd7a4a268d2cc5145b17adcaa82757fdee1d06d748b4c24137807710ecb
   patches:
     - patches/0001-no-code-sign.patch
     - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch


### PR DESCRIPTION
compiler-rt 22.1.2

**Destination channel:** defaults

### Links

- [PKG-13402](https://anaconda.atlassian.net/browse/PKG-13402)
- [PKG-12851](https://anaconda.atlassian.net/browse/PKG-12851) (LLVM 22 epic)
- [Upstream repository](https://github.com/llvm/llvm-project)
- [Upstream changelog/diff](https://releases.llvm.org/22.1.0/docs/ReleaseNotes.html)

### Explanation of changes:

- Updated version from 21.1.8 to 22.1.2 and SHA256
- Updated `c_compiler_version` / `cxx_compiler_version` to 22.1.2 for macOS
- LLVM 22 Stage 0 packages from `xkong-staging` on anaconda.org

[PKG-13402]: https://anaconda.atlassian.net/browse/PKG-13402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-12851]: https://anaconda.atlassian.net/browse/PKG-12851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Note:** This PR uses `https://conda.anaconda.org/xkong-staging` instead of PBP staging channels because PBP staging corrupts large files (>400MB) during download — see [SIR-2834](https://anaconda.atlassian.net/browse/SIR-2834). All LLVM 22 Stage 0/1/2 packages were downloaded from TaskCluster artifacts and uploaded to `xkong-staging` on anaconda.org as a workaround. This channel reference should be removed after packages are promoted to pkgs/main.

[SIR-2834]: https://anaconda.atlassian.net/browse/SIR-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ