### PR TITLE
compiler-rt win-arm64 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
-# All LLVM 22 packages on anaconda.org (bypass PBP staging, SIR-2834)
-channels:
-  - https://conda.anaconda.org/xkong-staging
-
-aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,8 @@ outputs:
       commands:
         - echo {{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}
         - test -f $PREFIX/lib/clang/{{ major_ver }}/lib/darwin/libclang_rt.osx.a                            # [osx]
-        - if not exist %PREFIX%\lib\clang\{{ major_ver }}\lib\windows\clang_rt.builtins-x86_64.lib exit 1   # [win]
+        - if not exist %PREFIX%\lib\clang\{{ major_ver }}\lib\windows\clang_rt.builtins-x86_64.lib exit 1   # [win and x86_64]
+        - if not exist %PREFIX%\lib\clang\{{ major_ver }}\lib\windows\clang_rt.builtins-aarch64.lib exit 1  # [win and arm64]
 
   - name: compiler-rt
     requirements:
@@ -80,7 +81,8 @@ outputs:
         # - sed "s/@MACOSX_DEPLOYMENT_TARGET@/{{ NEW_TARGET }}/g" test.c.in > test.c
         # - clang -mmacosx-version-min={{ MACOSX_DEPLOYMENT_TARGET }} test.c  # [osx]
         - test -f $PREFIX/lib/clang/{{ major_ver }}/include/sanitizer/asan_interface.h                      # [unix]
-        - if not exist %LIBRARY_LIB%\clang\{{ major_ver }}\lib\windows\clang_rt.builtins-x86_64.lib exit 1  # [win]
+        - if not exist %LIBRARY_LIB%\clang\{{ major_ver }}\lib\windows\clang_rt.builtins-x86_64.lib exit 1  # [win and x86_64]
+        - if not exist %LIBRARY_LIB%\clang\{{ major_ver }}\lib\windows\clang_rt.builtins-aarch64.lib exit 1  # [win and arm64]
 
 about:
   home: https://llvm.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0002-Revert-Declare-_availability_version_check-as-weak_i.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
compiler-rt rebuild with win-arm64 support

**Destination channel:** defaults

### Links

- [PKG-15380](https://anaconda.atlassian.net/browse/PKG-15380) 


### Explanation of changes:

- Remove abs.yaml
- Bump build number
- Update tests to support win-arm64


[PKG-15380]: https://anaconda.atlassian.net/browse/PKG-15380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ